### PR TITLE
Exit HYP mode on Raspberry Pi

### DIFF
--- a/src/runtime/rt0_tamago_arm.s
+++ b/src/runtime/rt0_tamago_arm.s
@@ -5,6 +5,21 @@
 #include "textflag.h"
 
 TEXT _rt0_arm_tamago(SB),NOSPLIT,$0
+	// Raspberry Pi firmware sets CPU to HYP mode.
+	// Detect if in HYP mode and switch out of HYP mode
+	// to SVC mode (borrow technique from Linux kernel).
+	WORD	$0xe10f0000 	// mrs	r0, CPSR
+	WORD	$0xe220001a 	// eor	r0, r0, #26
+	WORD	$0xe310001f 	// tst	r0, #31
+	WORD	$0xe3c0001f 	// bic	r0, r0, #31
+	WORD	$0xe38000d3 	// orr	r0, r0, #211	; 0xd3
+	WORD	$0x1a000004 	// bne	#0x18 (past eret)
+	WORD	$0xe3800c01 	// orr	r0, r0, #256	; 0x100
+	WORD	$0xe28fe00c 	// add	lr, pc, #12
+	WORD	$0xe16ff000 	// msr	SPSR_fsxc, r0
+	WORD	$0xe12ef30e 	// msr	ELR_hyp, lr
+	WORD	$0xe160006e 	// eret
+
 	// Disable MMU as soon as possible. Will be re-enabled in mmuinit().
 	MRC	15, 0, R0, C1, C0, 0
 	BIC	$0x1, R0

--- a/src/runtime/rt0_tamago_arm.s
+++ b/src/runtime/rt0_tamago_arm.s
@@ -8,17 +8,17 @@ TEXT _rt0_arm_tamago(SB),NOSPLIT,$0
 	// Raspberry Pi firmware sets CPU to HYP mode.
 	// Detect if in HYP mode and switch out of HYP mode
 	// to SVC mode (borrow technique from Linux kernel).
-	WORD	$0xe10f0000 	// mrs	r0, CPSR
-	WORD	$0xe220001a 	// eor	r0, r0, #26
-	WORD	$0xe310001f 	// tst	r0, #31
-	WORD	$0xe3c0001f 	// bic	r0, r0, #31
-	WORD	$0xe38000d3 	// orr	r0, r0, #211	; 0xd3
-	WORD	$0x1a000004 	// bne	#0x18 (past eret)
-	WORD	$0xe3800c01 	// orr	r0, r0, #256	; 0x100
-	WORD	$0xe28fe00c 	// add	lr, pc, #12
-	WORD	$0xe16ff000 	// msr	SPSR_fsxc, r0
-	WORD	$0xe12ef30e 	// msr	ELR_hyp, lr
-	WORD	$0xe160006e 	// eret
+	WORD	$0xe10f0000	// mrs r0, CPSR
+	EOR	$0x1a, R0	// 0x1a = HYP mode
+	TST	$0x1f, R0
+	BNE	after_eret	// Skip ERET if not HYP mode
+	BIC	$0x1f, R0
+	ORR	$0x1d3, R0	// 0x1d3 = AIF masked, SVC mode
+	MOVW	$12(R15), R14	// add lr, pc, #12 (after_eret)
+	WORD	$0xe16ff000	// msr SPSR_fsxc, r0
+	WORD	$0xe12ef30e	// msr ELR_hyp, lr
+	WORD	$0xe160006e	// eret
+after_eret:
 
 	// Disable MMU as soon as possible. Will be re-enabled in mmuinit().
 	MRC	15, 0, R0, C1, C0, 0


### PR DESCRIPTION
I've tried using TamaGo on Raspberry Pi 2 (v1.1)

The Pi firmware initializes in HYP mode by default.  Being in HYP mode breaks set_exc_stack, so this change borrows the technique from the Linux kernel to use ERET to exit from HYP mode early in boot.

The code conditionally exits HYP mode, so should be safe on systems that do not initialize in HYP mode.