### PR TITLE
Add support for Pi Zero

### DIFF
--- a/src/runtime/os_tamago_arm.go
+++ b/src/runtime/os_tamago_arm.go
@@ -178,6 +178,12 @@ func signame(sig uint32) string {
 }
 
 func checkgoarm() {
+	// Permit GOARM=5 to enable software floating-point implementation.  The Pi Zero
+	// fails in the `check()` function using hardware floating point.
+	if goarm < 5 || goarm > 7 {
+		print("runtime: tamago requires ARMv5 through ARMv7. Recompile using GOARM=5, GOARM=6 or GOARM=7.\n")
+		exit(1)
+	}
 }
 
 //go:nosplit

--- a/src/runtime/os_tamago_arm.go
+++ b/src/runtime/os_tamago_arm.go
@@ -178,11 +178,6 @@ func signame(sig uint32) string {
 }
 
 func checkgoarm() {
-	// tamago/ARM only supports ARMv7
-	if goarm != 7 {
-		print("runtime: tamago requires ARMv7. Recompile using GOARM=7.\n")
-		exit(1)
-	}
 }
 
 //go:nosplit

--- a/src/runtime/os_tamago_arm.go
+++ b/src/runtime/os_tamago_arm.go
@@ -178,8 +178,6 @@ func signame(sig uint32) string {
 }
 
 func checkgoarm() {
-	// Permit GOARM=5 to enable software floating-point implementation.  The Pi Zero
-	// fails in the `check()` function using hardware floating point.
 	if goarm < 5 || goarm > 7 {
 		print("runtime: tamago requires ARMv5 through ARMv7. Recompile using GOARM=5, GOARM=6 or GOARM=7.\n")
 		exit(1)

--- a/src/runtime/sys_tamago_arm.s
+++ b/src/runtime/sys_tamago_arm.s
@@ -11,15 +11,19 @@
 #include "textflag.h"
 
 TEXT runtime·invallpages(SB), NOSPLIT, $0
-	WORD	$0xf57ff06f		// isb sy
-	WORD	$0xf57ff04f		// dsb sy
+	// Flush Prefetch Buffer + Data Memory Barrier
+	MOVW	$0, R1
+	MCR 15, 0, R1, C7, C5, 4
+	MCR 15, 0, R1, C7, C10, 5
 
 	// Invalidate unified TLB
 	MCR	15, 0, R0, C8, C7, 0	// TLBIALL
 	RET
 
 TEXT runtime·dmb(SB), NOSPLIT, $0
-	WORD	$0xf57ff05e		// DMB ST
+	// Data Memory Barrier
+	MOVW $0, R0
+	MCR 15, 0, R0, C7, C10, 5
 	RET
 
 TEXT runtime·set_exc_stack(SB), NOSPLIT, $0-4
@@ -67,8 +71,10 @@ TEXT runtime·set_ttbr0(SB), NOSPLIT, $0-4
 	MOVW	$0x3, R0
 	MCR	15, 0, R0, C3, C0, 0
 
-	WORD	$0xf57ff06f	// isb sy
-	WORD	$0xf57ff04f	// dsb sy
+	// Flush Prefetch Buffer + Data Memory Barrier
+	MOVW	$0, R0
+	MCR 15, 0, R0, C7, C5, 4
+	MCR 15, 0, R0, C7, C10, 5
 
 	// Enable MMU
 	MRC	15, 0, R0, C1, C0, 0

--- a/src/runtime/sys_tamago_arm.s
+++ b/src/runtime/sys_tamago_arm.s
@@ -11,10 +11,10 @@
 #include "textflag.h"
 
 TEXT runtime·invallpages(SB), NOSPLIT, $0
-	// Flush Prefetch Buffer + Data Memory Barrier
+	// Invalidate Instruction Cache + DSB
 	MOVW	$0, R1
-	MCR 15, 0, R1, C7, C5, 4
-	MCR 15, 0, R1, C7, C10, 5
+	MCR	15, 0, R1, C7, C5, 0
+	MCR	15, 0, R1, C7, C10, 4
 
 	// Invalidate unified TLB
 	MCR	15, 0, R0, C8, C7, 0	// TLBIALL
@@ -22,8 +22,8 @@ TEXT runtime·invallpages(SB), NOSPLIT, $0
 
 TEXT runtime·dmb(SB), NOSPLIT, $0
 	// Data Memory Barrier
-	MOVW $0, R0
-	MCR 15, 0, R0, C7, C10, 5
+	MOVW	$0, R0
+	MCR	15, 0, R0, C7, C10, 5
 	RET
 
 TEXT runtime·set_exc_stack(SB), NOSPLIT, $0-4
@@ -71,10 +71,10 @@ TEXT runtime·set_ttbr0(SB), NOSPLIT, $0-4
 	MOVW	$0x3, R0
 	MCR	15, 0, R0, C3, C0, 0
 
-	// Flush Prefetch Buffer + Data Memory Barrier
+	// Invalidate Instruction Cache + DSB
 	MOVW	$0, R0
-	MCR 15, 0, R0, C7, C5, 4
-	MCR 15, 0, R0, C7, C10, 5
+	MCR	15, 0, R0, C7, C5, 0
+	MCR	15, 0, R0, C7, C10, 4
 
 	// Enable MMU
 	MRC	15, 0, R0, C1, C0, 0


### PR DESCRIPTION
* Drop ARMv7 check since Pi Zero (currently) needs ARMv5
* Use MCR instructions for memory barrier and prefetch flush
