### PR TITLE
tamago pread: have it properly lock the fs

### DIFF
--- a/src/syscall/fs_tamago.go
+++ b/src/syscall/fs_tamago.go
@@ -333,6 +333,12 @@ func (f *fsysFile) stat(st *Stat_t) error {
 	return nil
 }
 
+func (f *fsysFile) pread(b []byte, offset int64) (int, error) {
+	f.fsys.mu.Lock()
+	defer f.fsys.mu.Unlock()
+	return f.preadLocked(b, offset)
+}
+
 func (f *fsysFile) read(b []byte) (int, error) {
 	f.fsys.mu.Lock()
 	defer f.fsys.mu.Unlock()
@@ -393,10 +399,6 @@ func (f *fsysFile) Pwrite(b []byte, offset int64) (int, error) {
 	f.fsys.mu.Lock()
 	defer f.fsys.mu.Unlock()
 	return f.pwriteLocked(b, offset)
-}
-
-func (f *fsysFile) pread(b []byte, offset int64) (int, error) {
-	return f.preadLocked(b, offset)
 }
 
 func (f *fsysFile) preadLocked(b []byte, offset int64) (int, error) {


### PR DESCRIPTION
pread was not properly locking the fs before calling
preadLocked().

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
